### PR TITLE
change to package.json to run website on windows

### DIFF
--- a/website/package.json
+++ b/website/package.json
@@ -23,7 +23,7 @@
     "marked": "^0.3.3"
   },
   "scripts": {
-    "prepublish": "./node_modules/bower/bin/bower install",
+    "prepublish": "node node_modules/bower/bin/bower install",
     "clean": "gulp clean",
     "build": "gulp",
     "start": "gulp liveReload",


### PR DESCRIPTION
Re **chore(gulp): changes to gulpfile to run on windows #2972** this was necessary to be able to install and run the example website on Windows, prerequisite to run the tests.
